### PR TITLE
Fix duplicate nlohmann_json library definition

### DIFF
--- a/examples/IfcJsonNetRenderer/CMakeLists.txt
+++ b/examples/IfcJsonNetRenderer/CMakeLists.txt
@@ -48,13 +48,8 @@ set(BUILD_GOOGLETEST OFF CACHE BOOL "Build googletest" FORCE)
 
 FetchContent_MakeAvailable(jsonnet)
 
-# Fetch nlohmann/json for JSON handling
-FetchContent_Declare(
-    json
-    GIT_REPOSITORY https://github.com/nlohmann/json.git
-    GIT_TAG v3.11.3
-)
-FetchContent_MakeAvailable(json)
+# nlohmann/json is already included as a dependency of jsonnet
+# No need to fetch it separately
 
 LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/Debug)
 LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/${CMAKE_BUILD_TYPE})
@@ -73,7 +68,6 @@ TARGET_LINK_LIBRARIES(IfcJsonNetRenderer
     optimized IfcPlusPlus debug IfcPlusPlusd
     Crow::Crow
     jsonnet_static
-    nlohmann_json::nlohmann_json
     Threads::Threads
 )
 


### PR DESCRIPTION
Remove redundant nlohmann/json dependency to resolve CMake target redefinition error.

The `nlohmann_json` library was being fetched explicitly, but it is already included as a dependency of `jsonnet`, leading to a CMake error where the target `nlohmann_json` was defined twice. This PR removes the redundant fetch and link.

---
<a href="https://cursor.com/background-agent?bcId=bc-1608182b-1b43-4c58-b9f6-f3900e110edd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1608182b-1b43-4c58-b9f6-f3900e110edd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>