### PR TITLE
Fix the error

### DIFF
--- a/examples/IfcJsonNetRenderer/CMakeLists.txt
+++ b/examples/IfcJsonNetRenderer/CMakeLists.txt
@@ -55,10 +55,10 @@ LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/Debug)
 LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/${CMAKE_BUILD_TYPE})
 
 ADD_EXECUTABLE(IfcJsonNetRenderer 
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/main.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/ifc_parser.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/jsonnet_renderer.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/rest_endpoints.cpp
+    src/main.cpp
+    src/ifc_parser.cpp
+    src/jsonnet_renderer.cpp
+    src/rest_endpoints.cpp
 )
 
 set_target_properties(IfcJsonNetRenderer PROPERTIES DEBUG_POSTFIX "d")
@@ -74,16 +74,16 @@ TARGET_LINK_LIBRARIES(IfcJsonNetRenderer
 TARGET_INCLUDE_DIRECTORIES(IfcJsonNetRenderer
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/ifcpp/IFC4X3/include
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/glm
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/include
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/src/include
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/src/common
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/build/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/glm
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/ifcpp/IFC4X3/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/glm
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/src/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/src/common
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/build/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/glm
     ${jsonnet_SOURCE_DIR}/include
 )
         


### PR DESCRIPTION
Correct source file and include directory paths in `examples/IfcJsonNetRenderer/CMakeLists.txt` to resolve CMake configuration errors.

The previous configuration used an undefined `IFCPP_SOURCE_DIR` variable, leading to "file not found" errors during CMake configuration. This PR updates the paths to be relative to the current CMakeLists.txt file, ensuring correct resolution of source files and include directories.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2898bb4-b39c-4f77-8361-6a5e22495ec2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2898bb4-b39c-4f77-8361-6a5e22495ec2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>