### PR TITLE
Fix the error

### DIFF
--- a/examples/IfcJsonNetRenderer/CMakeLists_new.txt
+++ b/examples/IfcJsonNetRenderer/CMakeLists_new.txt
@@ -27,11 +27,11 @@ find_package(Threads REQUIRED)
 # Include FetchContent for downloading dependencies
 include(FetchContent)
 
-# Fetch Crow framework
+# Fetch Crow framework (use newer version compatible with Boost 1.88)
 FetchContent_Declare(
     crow
     GIT_REPOSITORY https://github.com/CrowCpp/Crow.git
-    GIT_TAG v1.0+5
+    GIT_TAG v1.2.0
 )
 FetchContent_MakeAvailable(crow)
 
@@ -55,10 +55,10 @@ LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/Debug)
 LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/${CMAKE_BUILD_TYPE})
 
 ADD_EXECUTABLE(IfcJsonNetRenderer 
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/main.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/ifc_parser.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/jsonnet_renderer.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/rest_endpoints.cpp
+    src/main.cpp
+    src/ifc_parser.cpp
+    src/jsonnet_renderer.cpp
+    src/rest_endpoints.cpp
 )
 
 set_target_properties(IfcJsonNetRenderer PROPERTIES DEBUG_POSTFIX "d")
@@ -74,17 +74,18 @@ TARGET_LINK_LIBRARIES(IfcJsonNetRenderer
 TARGET_INCLUDE_DIRECTORIES(IfcJsonNetRenderer
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/ifcpp/IFC4X3/include
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/glm
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/include
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/src/include
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/src/common
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/build/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/glm
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/ifcpp/IFC4X3/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/glm
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/src/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/src/common
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/build/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/glm
     ${jsonnet_SOURCE_DIR}/include
+    ${jsonnet_SOURCE_DIR}/third_party/json/include
 )
         
 INSTALL(

--- a/examples/IfcJsonNetRenderer/examples/IfcJsonNetRenderer/CMakeLists_fixed.txt
+++ b/examples/IfcJsonNetRenderer/examples/IfcJsonNetRenderer/CMakeLists_fixed.txt
@@ -1,0 +1,93 @@
+CMAKE_MINIMUM_REQUIRED (VERSION 3.7.2)
+
+PROJECT(IfcJsonNetRenderer)
+
+IF(NOT CMAKE_BUILD_TYPE)
+   SET(CMAKE_BUILD_TYPE "Release")
+ENDIF()
+
+IF(NOT WIN32)
+    SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+ENDIF(NOT WIN32)
+
+ADD_DEFINITIONS(-DUNICODE)
+ADD_DEFINITIONS(-D_UNICODE)
+ADD_DEFINITIONS(-DIFCQUERY_STATIC_LIB)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find required packages
+find_package(Threads REQUIRED)
+
+# Include FetchContent for downloading dependencies
+include(FetchContent)
+
+# Fetch Crow framework (use newer version compatible with Boost 1.88)
+FetchContent_Declare(
+    crow
+    GIT_REPOSITORY https://github.com/CrowCpp/Crow.git
+    GIT_TAG v1.2.0
+)
+FetchContent_MakeAvailable(crow)
+
+# Fetch jsonnet header-only library
+FetchContent_Declare(
+    jsonnet
+    GIT_REPOSITORY https://github.com/google/jsonnet.git
+    GIT_TAG v0.20.0
+)
+
+# Disable googletest for jsonnet to avoid download issues
+set(BUILD_TESTS OFF CACHE BOOL "Build tests" FORCE)
+set(BUILD_GOOGLETEST OFF CACHE BOOL "Build googletest" FORCE)
+
+FetchContent_MakeAvailable(jsonnet)
+
+LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/Debug)
+LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/${CMAKE_BUILD_TYPE})
+
+ADD_EXECUTABLE(IfcJsonNetRenderer 
+    src/main.cpp
+    src/ifc_parser.cpp
+    src/jsonnet_renderer.cpp
+    src/rest_endpoints.cpp
+)
+
+set_target_properties(IfcJsonNetRenderer PROPERTIES DEBUG_POSTFIX "d")
+set_target_properties(IfcJsonNetRenderer PROPERTIES CXX_STANDARD 17)
+
+TARGET_LINK_LIBRARIES(IfcJsonNetRenderer 
+    optimized IfcPlusPlus debug IfcPlusPlusd
+    Crow::Crow
+    jsonnet_static
+    Threads::Threads
+)
+
+TARGET_INCLUDE_DIRECTORIES(IfcJsonNetRenderer
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/ifcpp/IFC4X3/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/glm
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/src/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/src/common
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/Carve/build/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../IfcPlusPlus/src/external/glm
+    ${jsonnet_SOURCE_DIR}/include
+    ${jsonnet_SOURCE_DIR}/third_party/json/include
+)
+        
+INSTALL(
+    TARGETS IfcJsonNetRenderer
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION bin
+    ARCHIVE DESTINATION lib
+)


### PR DESCRIPTION
Updates `IfcJsonNetRenderer` CMake configuration to resolve build errors with Crow/Boost compatibility and header paths.

This PR addresses several CMake-related build issues:
- Updates the Crow framework version to `v1.2.0` to ensure compatibility with newer Boost versions (e.g., 1.88.0), fixing `io_service` related errors.
- Corrects include paths for `nlohmann/json.hpp` by adding the necessary `jsonnet_SOURCE_DIR/third_party/json/include` directory.
- Adjusts source file and include directory paths from absolute `${IFCPP_SOURCE_DIR}` to relative paths to ensure correct resolution during configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-a54981e9-f75c-4ede-b82e-8aa0300d3af2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a54981e9-f75c-4ede-b82e-8aa0300d3af2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>