### PR TITLE
Fix the error

### DIFF
--- a/examples/IfcJsonNetRenderer/CMakeLists.txt
+++ b/examples/IfcJsonNetRenderer/CMakeLists.txt
@@ -18,6 +18,8 @@ ENDIF(NOT WIN32)
 ADD_DEFINITIONS(-DUNICODE)
 ADD_DEFINITIONS(-D_UNICODE)
 ADD_DEFINITIONS(-DIFCQUERY_STATIC_LIB)
+ADD_DEFINITIONS(-DCROW_ENABLE_COMPRESSION=0)
+ADD_DEFINITIONS(-DBOOST_ASIO_NO_DEPRECATED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -27,12 +29,19 @@ find_package(Threads REQUIRED)
 # Include FetchContent for downloading dependencies
 include(FetchContent)
 
-# Fetch Crow framework
+# Fetch Crow framework - use master branch for better compatibility
 FetchContent_Declare(
     crow
     GIT_REPOSITORY https://github.com/CrowCpp/Crow.git
-    GIT_TAG v1.0+5
+    GIT_TAG master
 )
+
+# Disable Crow features we don't need
+set(CROW_BUILD_EXAMPLES OFF CACHE BOOL "Build Crow examples")
+set(CROW_BUILD_TESTS OFF CACHE BOOL "Build Crow tests")
+set(CROW_ENABLE_SSL OFF CACHE BOOL "Enable SSL")
+set(CROW_ENABLE_COMPRESSION OFF CACHE BOOL "Enable compression")
+
 FetchContent_MakeAvailable(crow)
 
 # Fetch jsonnet header-only library
@@ -48,17 +57,18 @@ set(BUILD_GOOGLETEST OFF CACHE BOOL "Build googletest" FORCE)
 
 FetchContent_MakeAvailable(jsonnet)
 
-# nlohmann/json is already included as a dependency of jsonnet
-# No need to fetch it separately
+# Set up paths
+get_filename_component(IFCPP_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
+set(IFCPP_SOURCE_DIR ${IFCPP_ROOT})
 
-LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/Debug)
-LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/${CMAKE_BUILD_TYPE})
+LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/../../IfcPlusPlus/Debug)
+LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/../../IfcPlusPlus/${CMAKE_BUILD_TYPE})
 
 ADD_EXECUTABLE(IfcJsonNetRenderer 
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/main.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/ifc_parser.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/jsonnet_renderer.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/rest_endpoints.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ifc_parser.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/jsonnet_renderer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/rest_endpoints.cpp
 )
 
 set_target_properties(IfcJsonNetRenderer PROPERTIES DEBUG_POSTFIX "d")
@@ -74,17 +84,19 @@ TARGET_LINK_LIBRARIES(IfcJsonNetRenderer
 TARGET_INCLUDE_DIRECTORIES(IfcJsonNetRenderer
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/ifcpp/IFC4X3/include
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/glm
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/include
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/src/include
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/src/common
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/build/src
-    ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/glm
+    ${IFCPP_ROOT}/IfcPlusPlus/src
+    ${IFCPP_ROOT}/IfcPlusPlus/src/ifcpp/IFC4X3/include
+    ${IFCPP_ROOT}/IfcPlusPlus/src/external
+    ${IFCPP_ROOT}/IfcPlusPlus/src/external/glm
+    ${IFCPP_ROOT}/IfcPlusPlus/src/external/Carve/include
+    ${IFCPP_ROOT}/IfcPlusPlus/src/external/Carve/src
+    ${IFCPP_ROOT}/IfcPlusPlus/src/external/Carve/src/include
+    ${IFCPP_ROOT}/IfcPlusPlus/src/external/Carve/src/common
+    ${IFCPP_ROOT}/IfcPlusPlus/src/external/Carve/build/src
+    ${IFCPP_ROOT}/IfcPlusPlus/src/external/glm
     ${jsonnet_SOURCE_DIR}/include
+    ${jsonnet_SOURCE_DIR}/third_party/json
+    ${jsonnet_SOURCE_DIR}/third_party/json/single_include
 )
         
 INSTALL(

--- a/examples/IfcJsonNetRenderer/src/main.cpp
+++ b/examples/IfcJsonNetRenderer/src/main.cpp
@@ -118,7 +118,8 @@ int main(int argc, char* argv[]) {
         g_app = &app;
         
         // Setup CORS middleware
-        app.use_compression(crow::compression::algorithm::GZIP);
+        // TODO: Enable compression once Crow version supports it
+        // app.use_compression(crow::compression::algorithm::GZIP);
         
         // Create REST endpoints handler
         RestEndpoints endpoints;


### PR DESCRIPTION
Update CMake configuration and Crow dependency to fix build errors related to Boost compatibility, pathing, and compression.

The project was failing to build due to several issues:
1.  **Crow/Boost incompatibility:** The Crow library's `v1.0+5` tag uses deprecated Boost Asio features (`io_service`) and its compression feature was causing build failures with newer Boost versions. This is addressed by switching to Crow's `master` branch, disabling compression, and adding Boost deprecation definitions.
2.  **Incorrect file paths:** CMake variables like `IFCPP_SOURCE_DIR` were not correctly defined or used, leading to source files and include directories not being found. This is fixed by defining `IFCPP_ROOT` and using relative paths.
3.  **nlohmann/json include path:** The nlohmann/json header was not found, as it's now provided as a transitive dependency via jsonnet. The include path is explicitly added.

---
<a href="https://cursor.com/background-agent?bcId=bc-c17596b1-c3ef-4b73-8c02-5fdf9e7b4124">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c17596b1-c3ef-4b73-8c02-5fdf9e7b4124">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>