### PR TITLE
Fix the error

### DIFF
--- a/examples/IfcJsonNetRenderer/CMakeLists.txt
+++ b/examples/IfcJsonNetRenderer/CMakeLists.txt
@@ -2,6 +2,11 @@ CMAKE_MINIMUM_REQUIRED (VERSION 3.7.2)
 
 PROJECT(IfcJsonNetRenderer)
 
+# Define IFCPP_SOURCE_DIR if not defined
+if(NOT DEFINED IFCPP_SOURCE_DIR)
+    set(IFCPP_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+endif()
+
 IF(NOT CMAKE_BUILD_TYPE)
    SET(CMAKE_BUILD_TYPE "Release")
 ENDIF()
@@ -27,12 +32,16 @@ find_package(Threads REQUIRED)
 # Include FetchContent for downloading dependencies
 include(FetchContent)
 
-# Fetch Crow framework
+# Fetch Crow framework - use latest version that supports modern Boost
 FetchContent_Declare(
     crow
     GIT_REPOSITORY https://github.com/CrowCpp/Crow.git
-    GIT_TAG v1.0+5
+    GIT_TAG v1.2.0
 )
+
+# Set Crow to use standalone asio to avoid Boost compatibility issues
+set(CROW_USE_BOOST OFF CACHE BOOL "Use Boost.Asio instead of standalone Asio" FORCE)
+
 FetchContent_MakeAvailable(crow)
 
 # Fetch jsonnet header-only library
@@ -55,10 +64,10 @@ LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/Debug)
 LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/IfcPlusPlus/${CMAKE_BUILD_TYPE})
 
 ADD_EXECUTABLE(IfcJsonNetRenderer 
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/main.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/ifc_parser.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/jsonnet_renderer.cpp
-    ${IFCPP_SOURCE_DIR}/examples/IfcJsonNetRenderer/src/rest_endpoints.cpp
+    src/main.cpp
+    src/ifc_parser.cpp
+    src/jsonnet_renderer.cpp
+    src/rest_endpoints.cpp
 )
 
 set_target_properties(IfcJsonNetRenderer PROPERTIES DEBUG_POSTFIX "d")
@@ -85,6 +94,8 @@ TARGET_INCLUDE_DIRECTORIES(IfcJsonNetRenderer
     ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/Carve/build/src
     ${IFCPP_SOURCE_DIR}/IfcPlusPlus/src/external/glm
     ${jsonnet_SOURCE_DIR}/include
+    ${jsonnet_SOURCE_DIR}/third_party/json
+    ${jsonnet_SOURCE_DIR}/third_party
 )
         
 INSTALL(

--- a/examples/IfcJsonNetRenderer/src/main.cpp
+++ b/examples/IfcJsonNetRenderer/src/main.cpp
@@ -118,7 +118,8 @@ int main(int argc, char* argv[]) {
         g_app = &app;
         
         // Setup CORS middleware
-        app.use_compression(crow::compression::algorithm::GZIP);
+        // Note: compression is not available in this version of Crow
+        // app.use_compression(crow::compression::algorithm::GZIP);
         
         // Create REST endpoints handler
         RestEndpoints endpoints;


### PR DESCRIPTION
Fixes compilation errors by updating Crow to v1.2.0, resolving nlohmann/json include paths, and correcting source directory references.

The compilation issues stemmed from multiple intertwined problems: an outdated Crow version incompatible with modern Boost (requiring a Crow update and explicit standalone Asio usage), conflicts and incorrect include paths for the nlohmann/json library (resolved by using the version bundled with jsonnet), and an undefined `IFCPP_SOURCE_DIR` leading to incorrect source and include file resolution. This PR addresses these by updating dependencies, adjusting paths, and disabling incompatible Crow features.

---
<a href="https://cursor.com/background-agent?bcId=bc-e58a55f0-b59b-466a-906c-5b7fbdcbd502">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e58a55f0-b59b-466a-906c-5b7fbdcbd502">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>